### PR TITLE
disable bitrotten intrinsics

### DIFF
--- a/src/config.lisp
+++ b/src/config.lisp
@@ -22,7 +22,7 @@
 
 ;; N.B.: Intrinsic functions are still compiled, even if they're not
 ;; used by Hypergeometrica.
-#+(and sbcl (or x86-64))
+#+(and #:disable sbcl (or x86-64))
 (push :hypergeometrica-intrinsics *features*)
 
 

--- a/src/sbcl-intrinsics.lisp
+++ b/src/sbcl-intrinsics.lisp
@@ -16,24 +16,24 @@
     (sb-c:foldable sb-c:flushable sb-c:movable)
   :overwrite-fndb-silently t)
 
+(sb-c:defknown %%add128 ((unsigned-byte 64) (unsigned-byte 64)
+                         (unsigned-byte 64) (unsigned-byte 64))
+    (values (unsigned-byte 64) (unsigned-byte 64))
+    (sb-c:foldable sb-c:flushable sb-c:movable)
+  :overwrite-fndb-silently t)
+
+(sb-c:defknown %%sub128 ((unsigned-byte 64) (unsigned-byte 64)
+                         (unsigned-byte 64) (unsigned-byte 64))
+    (values (unsigned-byte 64) (unsigned-byte 64))
+    (sb-c:foldable sb-c:flushable sb-c:movable)
+  :overwrite-fndb-silently t)
+
 (sb-c:defknown %%mul128 ((unsigned-byte 64) (unsigned-byte 64))
     (values (unsigned-byte 64) (unsigned-byte 64))
     (sb-c:foldable sb-c:flushable sb-c:movable)
   :overwrite-fndb-silently t)
 
 (sb-c:defknown %%div128 ((unsigned-byte 64) (unsigned-byte 64) (unsigned-byte 64))
-    (values (unsigned-byte 64) (unsigned-byte 64))
-    (sb-c:foldable sb-c:flushable sb-c:movable)
-  :overwrite-fndb-silently t)
-
-(sb-c:defknown %%add128 ((unsigned-byte 64) (unsigned-byte 64)
-                       (unsigned-byte 64) (unsigned-byte 64))
-    (values (unsigned-byte 64) (unsigned-byte 64))
-    (sb-c:foldable sb-c:flushable sb-c:movable)
-  :overwrite-fndb-silently t)
-
-(sb-c:defknown %%sub128 ((unsigned-byte 64) (unsigned-byte 64)
-                       (unsigned-byte 64) (unsigned-byte 64))
     (values (unsigned-byte 64) (unsigned-byte 64))
     (sb-c:foldable sb-c:flushable sb-c:movable)
   :overwrite-fndb-silently t)


### PR DESCRIPTION
intrinsics have bitrotten due to SBCL changes; disable them