### PR TITLE
add SB-POSIX to ASD dependencies

### DIFF
--- a/hypergeometrica.asd
+++ b/hypergeometrica.asd
@@ -16,8 +16,8 @@
                #:cffi
                #:mmap
 
-               #:sb-mpfr                ; for testing
-               )
+               (:feature :sbcl #:sb-mpfr)
+               (:feature :sbcl #:sb-posix))
   :in-order-to ((asdf:test-op (asdf:test-op #:hypergeometrica/tests)))
   :around-compile (lambda (compile)
                     (let (#+sbcl (sb-ext:*derive-function-types* t))


### PR DESCRIPTION
Also guarded the SBCL dependencies behind the SBCL feature, as is done further below in the ASD file (though there remain various unguarded calls to SBCL packages throughout the source code), and removed the comment beside the SB-MPFR dependency, because it is used in more than just tests (in MPD-PI via MPD-RECIPROCAL).